### PR TITLE
fix timestamp function name

### DIFF
--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -197,7 +197,7 @@
 
 (defmethod sql.qp/unix-timestamp->honeysql [:duckdb :seconds]
   [_ _ expr]
-  [:make_timestamp (h2x/cast :DOUBLE expr)])
+  [:to_timestamp (h2x/cast :DOUBLE expr)])
 
 (defmethod sql.qp/->honeysql [:duckdb :regex-match-first]
   [driver [_ arg pattern]]


### PR DESCRIPTION
to_timestamp should be used instead of make_timestamp: https://duckdb.org/docs/sql/functions/timestamp