### PR TITLE
Update org.duckdb/duckdb_jdbc to v1.1.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.duckdb/duckdb_jdbc {:mvn/version "1.0.0"}}}
+ {org.duckdb/duckdb_jdbc {:mvn/version "1.1.0"}}}


### PR DESCRIPTION
We'd love to use v1.1.0 in our Metabase instance. Thanks!

As far as I can tell this update contains no breaking changes and is just performance improvements, features and fixes, so I think this is a safe upgrade?