### PR TITLE
bump duckdb version to 1.1.3, and add 2 connection configs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.duckdb/duckdb_jdbc {:mvn/version "1.1.0"}}}
+ {org.duckdb/duckdb_jdbc {:mvn/version "1.1.3"}}}

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -27,6 +27,12 @@ driver:
       display-name: Allow loading unsigned extensions
       default: false
       type: boolean
+    - name: memory_limit
+      display-name: Limit on the amount of memory that DuckDB can use (e.g., 1GB), defaults to 80% of RAM
+      required: false
+    - name: azure_transport_option_type
+      display-name: Azure transport option type
+      required: false
     - name: motherduck_token
       display-name: Motherduck Token
       type: secret

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -24,7 +24,7 @@
 
 (defn- jdbc-spec
   "Creates a spec for `clojure.java.jdbc` to use for connecting to DuckDB via JDBC from the given `opts`"
-  [{:keys [database_file, read_only, allow_unsigned_extensions, old_implicit_casting, motherduck_token], :as details}]
+  [{:keys [database_file, read_only, allow_unsigned_extensions, old_implicit_casting, motherduck_token, memory_limit, azure_transport_option_type], :as details}]
   (-> details 
       (merge
        {:classname         "org.duckdb.DuckDBDriver"
@@ -36,13 +36,17 @@
         "jdbc_stream_results" "true"}
        (when old_implicit_casting
          {"old_implicit_casting" (str old_implicit_casting)})
+       (when memory_limit
+         {"memory_limit" (str memory_limit)})
+        (when azure_transport_option_type
+          {"azure_transport_option_type" (str azure_transport_option_type)})
        (when allow_unsigned_extensions
         {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
        (when (seq (re-find #"^md:" database_file)) 
          {"motherduck_attach_mode"  "single"})    ;; when connecting to MotherDuck, explicitly connect to a single database
        (when (seq motherduck_token)     ;; Only configure the option if token is provided
          {"motherduck_token" motherduck_token}))
-      (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions :old_implicit_casting :motherduck_token) 
+      (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type) 
       sql-jdbc.common/handle-additional-options))
 
 (defn- remove-keys-with-prefix [details prefix]


### PR DESCRIPTION
- **update duckdb version to 1.1.3**
- **add 2 new configs** for https://github.com/MotherDuck-Open-Source/metabase_duckdb_driver/issues/19. The goal should be to support a ~/.duckdbrc -like config for a collection of queries to run right after connection creation, but it's more complicated - I'm still figuring out if it's possible. 
 
<img width="653" alt="Screenshot 2024-11-11 at 4 32 51 PM" src="https://github.com/user-attachments/assets/8f837d2f-fc6a-4bba-a880-8db87a2e243e">
