### PR TITLE
filter out md_information_schema tables

### DIFF
--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -225,7 +225,7 @@
     (.getResultSet stmt)
     (empty-rs)))
 
-(defn- is_motherduck_single_mode 
+(defn- is_motherduck
   [database_file]
   (and (seq (re-find #"^md:" database_file)) (> (count database_file) 3)))
 
@@ -241,7 +241,7 @@
                                ;; Additionally filter by db_name if connecting to MotherDuck, since
                                ;; multiple databases can be attached and information about the
                                ;; non-target database will be present in information_schema. 
-                                  (if (is_motherduck_single_mode database_file)
+                                  (if (is_motherduck database_file)
                                     (let [db_name (motherduck_db_name database_file)]
                                       (format "where table_catalog = '%s' " db_name))
                                     ""))]
@@ -267,7 +267,7 @@
                                   ;; Additionally filter by db_name if connecting to MotherDuck, since
                                   ;; multiple databases can be attached and information about the
                                   ;; non-target database will be present in information_schema. 
-                                  (if (is_motherduck_single_mode database_file)
+                                  (if (is_motherduck database_file)
                                     (let [db_name (motherduck_db_name database_file)]
                                       (format "and table_catalog = '%s' " db_name))
                                     ""))]

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -225,9 +225,26 @@
     (.getResultSet stmt)
     (empty-rs)))
 
+(defn- is_motherduck_single_mode 
+  [database_file]
+  (and (seq (re-find #"^md:" database_file)) (> (count database_file) 3)))
+
+(defn- motherduck_db_name
+  [database_file]
+  (subs database_file 3))
+
 (defmethod driver/describe-database :duckdb
   [driver database]
-  (let [get_tables_query "select * from information_schema.tables"]
+  (let 
+   [database_file (get (get database :details) :database_file)
+    get_tables_query (str "select * from information_schema.tables "
+                               ;; Additionally filter by db_name if connecting to MotherDuck, since
+                               ;; multiple databases can be attached and information about the
+                               ;; non-target database will be present in information_schema. 
+                                  (if (is_motherduck_single_mode database_file)
+                                    (let [db_name (motherduck_db_name database_file)]
+                                      (format "where table_catalog = '%s' " db_name))
+                                    ""))]
     {:tables
      (sql-jdbc.execute/do-with-connection-with-options
       driver database nil
@@ -242,9 +259,18 @@
 
 (defmethod driver/describe-table :duckdb
   [driver database {table_name :name, schema :schema}]
-  (let [get_columns_query (format 
-                           "select * from information_schema.columns where table_name = '%s' and table_schema = '%s'" 
-                           table_name schema)] 
+  (let [database_file (get (get database :details) :database_file)
+               get_columns_query (str 
+                                  (format 
+                                   "select * from information_schema.columns where table_name = '%s' and table_schema = '%s'" 
+                                   table_name schema) 
+                                  ;; Additionally filter by db_name if connecting to MotherDuck, since
+                                  ;; multiple databases can be attached and information about the
+                                  ;; non-target database will be present in information_schema. 
+                                  (if (is_motherduck_single_mode database_file)
+                                    (let [db_name (motherduck_db_name database_file)]
+                                      (format "and table_catalog = '%s' " db_name))
+                                    ""))]
     {:name   table_name
      :schema schema
      :fields


### PR DESCRIPTION
After this release https://motherduck.com/docs/about-motherduck/release-notes/#november-21-2024 MD_INFORMATION_SCHEMA tables will show up in the catalog when connecting to MotherDuck, so we need to filter by catalog_name when collecting the table schemas for MotherDuck connections.