### PR TITLE
Update duckdb to version 1.4.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.duckdb/duckdb_jdbc {:mvn/version "1.4.1.0"}}}
+ {org.duckdb/duckdb_jdbc {:mvn/version "1.4.3.0"}}}


### PR DESCRIPTION
I'm submitting a PR to upgrade duckdb to version 1.4.3 in order to avoid postgres secrets being leaked by duckdb and metabase when connecting to postgres through duckdb in metabase.

See this issue for more context: https://github.com/duckdb/duckdb-postgres/issues/368
See this PR for the fix: https://github.com/duckdb/duckdb-postgres/pull/383

This fix was picked up in Duckdb 1.4.2