### PR TITLE
Use search_path setting for schema and table filtering

### DIFF
--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -43,11 +43,16 @@ driver:
       type: text
       required: false
       placeholder: "INSTALL httpfs; LOAD httpfs;"
+    - name: filter_by_search_path
+      display-name: Show only schemas in search_path
+      default: false
+      type: boolean
     - advanced-options-start
     - merge:
         - additional-options
         - display-name: Additional DuckDB connection string options
           placeholder: 'http_keep_alive=false'
+    - default-advanced-options
 
 init:
   - step: load-namespace


### PR DESCRIPTION
## Summary
- Replace hardcoded MotherDuck database filtering with a flexible approach using DuckDB's `search_path` setting
- Allow users to configure visible databases/schemas via the `init_sql` setting (e.g., `SET search_path='my_db.schema1,other_db.schema2'`)
- Execute `init_sql` on cloned connections used for metadata queries, ensuring `search_path` is properly applied
- Fall back to `current_database().current_schema()` when `search_path` is empty or not set