### PR TITLE
allow integration test to run again

### DIFF
--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -1,7 +1,7 @@
 (ns metabase.test.data.duckdb
   (:require
    [clojure.java.io :as io]
-   [metabase.config :as config]
+   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]

--- a/test/metabase/test/data/motherduck.clj
+++ b/test/metabase/test/data/motherduck.clj
@@ -1,7 +1,7 @@
 (ns metabase.test.data.motherduck
   (:require
    [clojure.tools.logging :as log]
-   [metabase.config :as config]
+   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]


### PR DESCRIPTION
Integration tests have been totally broken. after this fix, a bunch of tests are still failing, but at least they are running