### PR TITLE
Fix Metabase main integration test failures

### DIFF
--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -13,34 +13,34 @@ jobs:
     
     steps:
     - name: Clone Metabase repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: metabase/metabase
         path: metabase
         
     - name: Checkout driver code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: metabase/modules/drivers/duckdb
         
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '21'
         
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: 'metabase/.nvmrc'
 
     - name: Install Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: '1.3.7'
+        bun-version: '1.3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
         
     - name: Set up Clojure
       uses: DeLaGuardo/setup-clojure@13.4
@@ -55,7 +55,7 @@ jobs:
         ./bin/build-driver.sh duckdb
         
     - name: Upload driver artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: metabase-duckdb-driver
         path: metabase/resources/modules/duckdb.metabase-driver.jar
@@ -71,34 +71,34 @@ jobs:
 
     steps:
     - name: Clone Metabase repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: metabase/metabase
         path: metabase
 
     - name: Checkout driver code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: metabase/modules/drivers/duckdb
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '21'
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: 'metabase/.nvmrc'
 
     - name: Install Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: '1.3.7'
+        bun-version: '1.3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
 
     - name: Set up Clojure
       uses: DeLaGuardo/setup-clojure@13.4

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -32,12 +32,12 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 'lts/*'
-        
-    - name: Install Yarn 1.x
-      run: |
-        npm install -g yarn@1
-        yarn --version
+        node-version-file: 'metabase/.nvmrc'
+
+    - name: Install Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: '1.3.7'
         
     - name: Set up Clojure
       uses: DeLaGuardo/setup-clojure@13.4
@@ -57,6 +57,43 @@ jobs:
         name: metabase-duckdb-driver
         path: metabase/resources/modules/duckdb.metabase-driver.jar
         if-no-files-found: error
+
+    - name: Patch Metabase test deps
+      working-directory: ./metabase
+      run: |
+        python - <<'PY'
+        from pathlib import Path
+
+        def replace_once(path_str: str, old: str, new: str) -> None:
+            path = Path(path_str)
+            text = path.read_text()
+            if new in text:
+                return
+            if old not in text:
+                raise RuntimeError(f"Could not patch {path}: expected snippet not found")
+            path.write_text(text.replace(old, new, 1))
+
+        replace_once(
+            "deps.edn",
+            '    "modules/drivers/vertica/test"]}',
+            '    "modules/drivers/vertica/test"\n'
+            '    "modules/drivers/duckdb/test"\n'
+            '    ]}',
+        )
+        replace_once(
+            "modules/drivers/deps.edn",
+            '  metabase/vertica            {:local/root "vertica"}}}',
+            '  metabase/vertica            {:local/root "vertica"}\n'
+            '  metabase/duckdb             {:local/root "duckdb"}\n'
+            '  }}',
+        )
+        replace_once(
+            ".clj-kondo/config.edn",
+            '              :vertica}}',
+            '              :vertica\n'
+            '              :duckdb}}',
+        )
+        PY
         
     - name: Run integration tests against MotherDuck
       working-directory: ./metabase
@@ -64,13 +101,11 @@ jobs:
       env:
           motherduck_token: ${{ secrets.motherduck_ci_user_token }}
       run: |
-        git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
-        MB_EDITION=ee yarn build-static-viz
-        DRIVERS=motherduck clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
+        MB_EDITION=ee bun run build-static-viz
+        DRIVERS=motherduck clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
 
     - name: Run integration tests against DuckDB local
       working-directory: ./metabase
       continue-on-error: true
       run: |
-        DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
-
+        DRIVERS=duckdb clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -61,6 +61,50 @@ jobs:
         path: metabase/resources/modules/duckdb.metabase-driver.jar
         if-no-files-found: error
 
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [motherduck, duckdb]
+    name: integration (${{ matrix.target }})
+
+    steps:
+    - name: Clone Metabase repository
+      uses: actions/checkout@v4
+      with:
+        repository: metabase/metabase
+        path: metabase
+
+    - name: Checkout driver code
+      uses: actions/checkout@v4
+      with:
+        path: metabase/modules/drivers/duckdb
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: 'metabase/.nvmrc'
+
+    - name: Install Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: '1.3.7'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Set up Clojure
+      uses: DeLaGuardo/setup-clojure@13.4
+      with:
+        cli: latest
+
     - name: Patch Metabase test deps
       working-directory: ./metabase
       run: |
@@ -97,18 +141,17 @@ jobs:
             '              :duckdb}}',
         )
         PY
-        
-    - name: Run integration tests against MotherDuck
+
+    - name: Build static viz
+      if: matrix.target == 'motherduck'
+      working-directory: ./metabase
+      run: |
+        MB_EDITION=ee bun run build-static-viz
+
+    - name: Run integration tests
       working-directory: ./metabase
       continue-on-error: true
       env:
-          motherduck_token: ${{ secrets.motherduck_ci_user_token }}
+        motherduck_token: ${{ matrix.target == 'motherduck' && secrets.motherduck_ci_user_token || '' }}
       run: |
-        MB_EDITION=ee bun run build-static-viz
-        DRIVERS=motherduck clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
-
-    - name: Run integration tests against DuckDB local
-      working-directory: ./metabase
-      continue-on-error: true
-      run: |
-        DRIVERS=duckdb clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
+        DRIVERS=${{ matrix.target }} clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -38,6 +38,9 @@ jobs:
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: '1.3.7'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
         
     - name: Set up Clojure
       uses: DeLaGuardo/setup-clojure@13.4

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -46,18 +46,18 @@
   "Check if the error is due to a database already being attached.
    This is expected when C3P0 reuses connections or wraps them in new proxies."
   [^Throwable e]
-  (let [msg (str (.getMessage e))]
-    (or (str/includes? msg "already exists")
-        (str/includes? msg "already attached"))))
+  (let [msg (str/lower-case (str (.getMessage e)))]
+    (or (str/includes? msg "already attached")
+        (and (str/includes? msg "attach")
+             (str/includes? msg "already exists")))))
 
 (defn- ensure-init-sql!
   "Execute init SQL on a connection if it hasn't been executed yet.
    This is safe to call multiple times on the same connection.
-   Used for both pooled connections and cloned connections for metadata queries.
 
-   Handles the case where ATTACH fails because the database is already attached,
-   which can happen when C3P0 reuses underlying connections but wraps them in
-   new proxy objects (causing our identity-based tracking to miss them)."
+   Handles ATTACH failures caused by the database already being attached, which
+   can happen when C3P0 reuses underlying connections but wraps them in new
+   proxy objects."
   [^Connection conn init-sql]
   (when (and init-sql
              (seq (str/trim init-sql))
@@ -71,7 +71,6 @@
       (catch Throwable e
         (if (already-attached-error? e)
           (do
-            ;; Database already attached - this is fine, mark as initialized
             (log/tracef "DuckDB database already attached, marking connection as initialized")
             (mark-connection-initialized! conn))
           (do
@@ -129,12 +128,14 @@
       [database_file ""])))
 
 (defn- remove-internal-connection-keys
-  "Metabase 0.59+ annotates effective connection details with internal keys that should
+  "Metabase annotates effective connection details with internal keys that should
    not be forwarded to DuckDB as JDBC properties."
   [details]
   (dissoc details
           :metabase.driver.connection/effective-connection-type
-          :metabase.driver.connection/database-id))
+          :metabase.driver.connection/database-id
+          :destination-database
+          "destination-database"))
 
 (defn- jdbc-spec
   "Creates a spec for `clojure.java.jdbc` to use for connecting to DuckDB via JDBC from the given `opts`"
@@ -147,11 +148,12 @@
          {:classname         "org.duckdb.DuckDBDriver"
           :subprotocol       "duckdb"
           :subname           (or database_file "")
-          "duckdb.read_only" (str read_only)
           "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
           "temp_directory"   (str database_file_base ".tmp")
           "jdbc_stream_results" "true"
           :TimeZone  "UTC"}
+         (when (some? read_only)
+           {"duckdb.read_only" (str read_only)})
          (when old_implicit_casting
            {"old_implicit_casting" (str old_implicit_casting)})
          (when memory_limit

--- a/test/metabase/test/data/motherduck.clj
+++ b/test/metabase/test/data/motherduck.clj
@@ -122,8 +122,11 @@
   (let [drop-sql (fn [db-name] (format "DROP DATABASE IF EXISTS \"%s\" CASCADE;" db-name))]
     (with-open [stmt (.createStatement conn)]
       (with-open [rset (.executeQuery stmt "select database_name from duckdb_databases() where type = 'motherduck' and database_name not in ('my_db', 'sample_data'); ")]
-        (while (.next rset) 
-          (let [db-name (.getString rset "database_name")]
+        (let [db-names (loop [names []]
+                         (if (.next rset)
+                           (recur (conj names (.getString rset "database_name")))
+                           names))]
+          (doseq [db-name db-names]
             (with-open [inner-stmt (.createStatement conn)]
               (.execute inner-stmt (drop-sql db-name)))))))))
 


### PR DESCRIPTION
Integration tests were failing because our CI test setup had drifted from upstream and the driver was forwarding Metabase-internal connection metadata to DuckDB. Also the MotherDuck test cleanup was mutating the catalog while iterating it (codex found it)

### FIx
- align the CI test workflow with current metabase/main (.nvmrc, bun, :ci aliases, inline deps patch)
- strip Metabase-internal connection keys before building DuckDB JDBC properties
- collect MotherDuck database names before dropping them during cleanup
- accept the newer DuckDB "attach already exists" error wording