### PR TITLE
Refactor integration test CI workflow

### DIFF
--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -13,34 +13,34 @@ jobs:
     
     steps:
     - name: Clone Metabase repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: metabase/metabase
         path: metabase
         
     - name: Checkout driver code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: metabase/modules/drivers/duckdb
         
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '21'
         
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: 'metabase/.nvmrc'
 
     - name: Install Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: '1.3.7'
+        bun-version: '1.3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
         
     - name: Set up Clojure
       uses: DeLaGuardo/setup-clojure@13.4
@@ -55,7 +55,7 @@ jobs:
         ./bin/build-driver.sh duckdb
         
     - name: Upload driver artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: metabase-duckdb-driver
         path: metabase/resources/modules/duckdb.metabase-driver.jar
@@ -71,34 +71,34 @@ jobs:
 
     steps:
     - name: Clone Metabase repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: metabase/metabase
         path: metabase
 
     - name: Checkout driver code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: metabase/modules/drivers/duckdb
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '21'
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: 'metabase/.nvmrc'
 
     - name: Install Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: '1.3.7'
+        bun-version: '1.3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
 
     - name: Set up Clojure
       uses: DeLaGuardo/setup-clojure@13.4

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -61,6 +61,50 @@ jobs:
         path: metabase/resources/modules/duckdb.metabase-driver.jar
         if-no-files-found: error
 
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [motherduck, duckdb]
+    name: integration (${{ matrix.target }})
+
+    steps:
+    - name: Clone Metabase repository
+      uses: actions/checkout@v4
+      with:
+        repository: metabase/metabase
+        path: metabase
+
+    - name: Checkout driver code
+      uses: actions/checkout@v4
+      with:
+        path: metabase/modules/drivers/duckdb
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: 'metabase/.nvmrc'
+
+    - name: Install Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: '1.3.7'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Set up Clojure
+      uses: DeLaGuardo/setup-clojure@13.4
+      with:
+        cli: latest
+
     - name: Patch Metabase test deps
       working-directory: ./metabase
       run: |
@@ -97,18 +141,17 @@ jobs:
             '              :duckdb}}',
         )
         PY
-        
-    - name: Run integration tests against MotherDuck
+
+    - name: Build static viz
+      if: matrix.target == 'motherduck'
+      working-directory: ./metabase
+      run: |
+        MB_EDITION=ee bun run build-static-viz
+
+    - name: Run integration tests
       working-directory: ./metabase
       continue-on-error: true
       env:
-          motherduck_token: ${{ secrets.motherduck_ci_user_token }}
+        motherduck_token: ${{ matrix.target == 'motherduck' && secrets.motherduck_ci_user_token || '' }}
       run: |
-        MB_EDITION=ee bun run build-static-viz
-        DRIVERS=motherduck clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
-
-    - name: Run integration tests against DuckDB local
-      working-directory: ./metabase
-      continue-on-error: true
-      run: |
-        DRIVERS=duckdb clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
+        DRIVERS=${{ matrix.target }} clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -38,6 +38,9 @@ jobs:
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: '1.3.7'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
         
     - name: Set up Clojure
       uses: DeLaGuardo/setup-clojure@13.4


### PR DESCRIPTION
Separate the CI workflow refactor from #87 and refresh the workflow to current action/Bun versions

### What
- run DuckDB and MotherDuck integration tests as a parallel matrix
-  install uv in CI
- bump GitHub Actions versions
- update Bun to 1.3.11