### PR TITLE
upgrade to duckdb 1.5.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.duckdb/duckdb_jdbc {:mvn/version "1.5.1.0"}}}
+ {org.duckdb/duckdb_jdbc {:mvn/version "1.5.2.0"}}}


### PR DESCRIPTION
## Summary
- Bump `org.duckdb/duckdb_jdbc` from 1.5.1.0 to 1.5.2.0