### PR TITLE
Fix error with connection-pool-type option on Metabse v63. Fixes #103

### DIFF
--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -131,11 +131,14 @@
   "Metabase annotates effective connection details with internal keys that should
    not be forwarded to DuckDB as JDBC properties."
   [details]
-  (dissoc details
-          :metabase.driver.connection/effective-connection-type
-          :metabase.driver.connection/database-id
-          :destination-database
-          "destination-database"))
+  (m/filter-keys
+   (fn [k]
+     (not (or (#{:connection-pool-type "connection-pool-type"
+                 :destination-database "destination-database"} k)
+              (and (keyword? k) (some? (namespace k)))
+              (and (string? k) (or (str/starts-with? k "metabase.")
+                                   (str/starts-with? k "metabase/"))))))
+   details))
 
 (defn- jdbc-spec
   "Creates a spec for `clojure.java.jdbc` to use for connecting to DuckDB via JDBC from the given `opts`"


### PR DESCRIPTION
Enhanced `remove-internal-connection-keys` in `src/metabase/driver/duckdb.clj` to filter out `connection-pool-type`, namespaced keys, and `metabase.` prefixed keys. This prevents internal Metabase settings from being forwarded to DuckDB as unrecognized JDBC options.